### PR TITLE
Add github stat collection persistence

### DIFF
--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -1,0 +1,21 @@
+name: github-repo-stats
+
+on:
+  schedule:
+    # Run this once per day, towards the end of the day for keeping the most
+    # recent data point most meaningful (hours are interpreted in UTC).
+    - cron: "0 23 * * *"
+  workflow_dispatch: # Allow for running this manually.
+
+jobs:
+  j1:
+    name: github-repo-stats
+    runs-on: ubuntu-latest
+    steps:
+      - name: run-ghrs
+        # Use latest release.
+        uses: jgehrcke/github-repo-stats@RELEASE
+        with:
+          ghtoken: ${{ secrets.ghrs_github_api_token }}
+
+


### PR DESCRIPTION
This PR adds a persistent tracker for repo views, clones, stars and forks.

Since we expect code to be distributed mainly like this, this will help us track the popularity of the source code. Whereas Docker Hub and PyPI based stats will help us track downloads of the actual pipeline (be it containerized or not).

Stats and reports are generated in the "github-repo-stats" branch.

If you want, you can copy this workflow into any other repo.

Just make sure of the following before you do so:
1. Make an empty branch "github-repo-stats" in the same repo. You can accomplish this with:

`git checkout --orphan github-repo-stats`

`git rm -rf .`

`git commit --allow-empty -m "added blank github-repo-stats branch"`

Then just push to the github-repo-stats branch on the actual repo.

2. Add the "GHRS_GITHUB_API_TOKEN" secret in repo settings -> Secrets and Variables.
You will need to generate this API token. You can do that from your github profile -> developer settings -> personal access tokens.
That token will need read/write to the repo in question, of course.