### PR TITLE
Solution to weird artifacts created by DLICV

### DIFF
--- a/niCHARTPipelines/MaskImage.py
+++ b/niCHARTPipelines/MaskImage.py
@@ -3,47 +3,7 @@ import nibabel as nib
 from scipy import ndimage
 from scipy.ndimage.measurements import label
 
-## Find bounding box for the foreground values in img, with a given padding percentage
-def calc_bbox_with_padding(img, perc_pad = 10):
-    
-    img = img.astype('uint8')
-    
-    ## Output is the coordinates of the bounding box
-    bcoors = np.zeros([3,2], dtype=int)
-    
-    ## Find the largest connected component 
-    ## INFO: In images with very large FOV DLICV may have small isolated regions in
-    ##       boundaries; so we calculate the bounding box based on the brain, not all
-    ##       foreground voxels
-    str_3D = np.array([[[0, 0, 0], [0, 1, 0], [0, 0, 0]],
-                       [[0, 1, 0], [1, 1, 1], [0, 1, 0]],
-                       [[0, 0, 0], [0, 1, 0], [0, 0, 0]]], dtype='uint8')
-    labeled, ncomp = label(img, str_3D)
-    sizes = ndimage.sum(img, labeled, range(ncomp + 1))
-    img_largest_cc = (labeled == np.argmax(sizes)).astype(int)
-
-    ## Find coors in each axis
-    for sel_axis in [0, 1, 2]:
-    
-        ## Get axes other than the selected
-        other_axes = [0, 1, 2]
-        other_axes.remove(sel_axis)
-        
-        ## Get img dim in selected axis
-        dim = img_largest_cc.shape[sel_axis]
-        
-        ## Find bounding box (index of first and last non-zero slices)
-        nonzero = np.any(img_largest_cc, axis = tuple(other_axes))
-        bbox= np.where(nonzero)[0][[0,-1]]    
-        
-        ## Add padding
-        size_pad = int(np.round((bbox[1] - bbox[0]) * perc_pad / 100))
-        b_min = int(np.max([0, bbox[0] - size_pad]))
-        b_max = int(np.min([dim, bbox[1] + size_pad]))
-        
-        bcoors[sel_axis, :] = [b_min, b_max]
-    
-    return bcoors
+from niCHARTPipelines.CombineMasks import calc_bbox_with_padding
 
 
 ###---------mask image-----------

--- a/niCHARTPipelines/MaskImage.py
+++ b/niCHARTPipelines/MaskImage.py
@@ -1,12 +1,27 @@
 import numpy as np
 import nibabel as nib
+from scipy import ndimage
+from scipy.ndimage.measurements import label
 
 ## Find bounding box for the foreground values in img, with a given padding percentage
 def calc_bbox_with_padding(img, perc_pad = 10):
     
+    img = img.astype('uint8')
+    
     ## Output is the coordinates of the bounding box
     bcoors = np.zeros([3,2], dtype=int)
     
+    ## Find the largest connected component 
+    ## INFO: In images with very large FOV DLICV may have small isolated regions in
+    ##       boundaries; so we calculate the bounding box based on the brain, not all
+    ##       foreground voxels
+    str_3D = np.array([[[0, 0, 0], [0, 1, 0], [0, 0, 0]],
+                       [[0, 1, 0], [1, 1, 1], [0, 1, 0]],
+                       [[0, 0, 0], [0, 1, 0], [0, 0, 0]]], dtype='uint8')
+    labeled, ncomp = label(img, str_3D)
+    sizes = ndimage.sum(img, labeled, range(ncomp + 1))
+    img_largest_cc = (labeled == np.argmax(sizes)).astype(int)
+
     ## Find coors in each axis
     for sel_axis in [0, 1, 2]:
     
@@ -15,10 +30,10 @@ def calc_bbox_with_padding(img, perc_pad = 10):
         other_axes.remove(sel_axis)
         
         ## Get img dim in selected axis
-        dim = img.shape[sel_axis]
+        dim = img_largest_cc.shape[sel_axis]
         
         ## Find bounding box (index of first and last non-zero slices)
-        nonzero = np.any(img, axis = tuple(other_axes))
+        nonzero = np.any(img_largest_cc, axis = tuple(other_axes))
         bbox= np.where(nonzero)[0][[0,-1]]    
         
         ## Add padding


### PR DESCRIPTION
This PR is related to #15. In essence:

It was detected that a number of images with large FOV (one dimension is relatively much larger than the others) confuse the nnUNet model for the DLICV step, leading to additional, erroneous brain areas to be detected. This then was further worsened by the DLMUSE nnUNet model, which produced artifacts of segmented brain regions at the very bottom of the images.

Solution: Introduced a fix in the application of the DLICV mask step in which:

After the DLICV brain mask is calculated, pick the single biggest component (which in theory is the brain itself), and compute a bounding box around it (which will include actual and disconnected brain regions, but exclude false disconnected regions due to vicinity).
Then, use this to crop the original picture, apply the DLICV mask on the cropped picture.
Run DLMUSE on the cropped & masked picture, and perform its steps as usual.
When recombining the mask and original pictures, recalculate the bounding box, to correctly place the cropped image on top of the original one.

In contrast to PR #15, this PR incorporates @ashishsingh18's suggestions for code deduplication. 